### PR TITLE
Support for GraphQL 3.x

### DIFF
--- a/src/Field/TextLongWithSectionsItem.php
+++ b/src/Field/TextLongWithSectionsItem.php
@@ -18,6 +18,7 @@ class TextLongWithSectionsItem extends TextLongItem {
       ->setComputed(TRUE)
       ->setClass(DocumentSectionsExtractor::class)
       ->setSetting('text source', 'value')
+      ->setDataType('section')
       ->setInternal(FALSE);
 
     return $properties;

--- a/src/Field/TextWithSummaryAndSectionsItem.php
+++ b/src/Field/TextWithSummaryAndSectionsItem.php
@@ -18,6 +18,7 @@ class TextWithSummaryAndSectionsItem extends TextWithSummaryItem {
       ->setComputed(TRUE)
       ->setClass(DocumentSectionsExtractor::class)
       ->setSetting('text source', 'value')
+      ->setDataType('section')
       ->setInternal(FALSE);
 
     return $properties;

--- a/src/Plugin/Deriver/SectionDeriverBase.php
+++ b/src/Plugin/Deriver/SectionDeriverBase.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Drupal\ckeditor5_sections\Plugin\Deriver;
+
+use Drupal\ckeditor5_sections\SectionsCollectorInterface;
+use Drupal\ckeditor5_sections\TypedData\DocumentSectionDataDefinition;
+use Drupal\Component\Plugin\Derivative\DeriverBase;
+use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
+use Drupal\Core\TypedData\TypedDataManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Base class for section derivers.
+ */
+class SectionDeriverBase extends DeriverBase implements ContainerDeriverInterface {
+
+  /**
+   * @var \Drupal\Core\TypedData\TypedDataManagerInterface
+   */
+  protected $typedDataManager;
+
+  /**
+   * @var \Drupal\ckeditor5_sections\SectionsCollectorInterface
+   */
+  protected $sectionsCollector;
+
+  /**
+   * @param \Drupal\Core\TypedData\TypedDataManagerInterface $typedDataManager
+   * @param \Drupal\ckeditor5_sections\SectionsCollectorInterface $sectionsCollector
+   */
+  public function __construct(
+    TypedDataManagerInterface $typedDataManager,
+    SectionsCollectorInterface $sectionsCollector
+  ) {
+    $this->sectionsCollector = $sectionsCollector;
+    $this->typedDataManager = $typedDataManager;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public static function create(ContainerInterface $container, $base_plugin_id) {
+    return new static(
+      $container->get('typed_data_manager'),
+      $container->get('ckeditor5_sections.sections_collector')
+    );
+  }
+
+  /**
+   * Returns all available sections as typed data definitions.
+   *
+   * @return \Drupal\Core\TypedData\DataDefinitionInterface[]
+   *   Array keys are data type IDs.
+   */
+  protected function getSectionTypeDefinitions() {
+    $result = [];
+    foreach ($this->sectionsCollector->getSections() as $sectionType => $section) {
+      if ($this->typedDataManager->hasDefinition("section:{$sectionType}")) {
+        $definition = $this->typedDataManager->createDataDefinition("section:{$sectionType}");
+        $result[$definition->getDataType()] = $definition;
+        $result += $this->getNestedSectionTypeDefinitions($definition);
+      }
+    }
+    return $result;
+  }
+
+  /**
+   * Returns nested sections as typed data definitions.
+   *
+   * @param \Drupal\Core\TypedData\DataDefinitionInterface $definition
+   *
+   * @return \Drupal\Core\TypedData\DataDefinitionInterface[]
+   *   Array keys are data type IDs.
+   */
+  protected function getNestedSectionTypeDefinitions($definition) {
+    $result = [];
+    if ($definition instanceof DocumentSectionDataDefinition) {
+      foreach ($definition->getPropertyDefinitions() as $propertyName => $propertyDefinition) {
+        if ($propertyDefinition  instanceof DocumentSectionDataDefinition) {
+          $result[$propertyDefinition->getDataType()] = $propertyDefinition;
+          $result += $this->getNestedSectionTypeDefinitions($propertyDefinition);
+        }
+      }
+    }
+    return $result;
+  }
+
+}

--- a/src/Plugin/Deriver/SectionPropertyDeriver.php
+++ b/src/Plugin/Deriver/SectionPropertyDeriver.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\ckeditor5_sections\Plugin\Deriver;
+
+use Drupal\ckeditor5_sections\TypedData\DocumentSectionDataDefinition;
+use Drupal\graphql\Utility\StringHelper;
+
+/**
+ * Deriver for section properties.
+ */
+class SectionPropertyDeriver extends SectionDeriverBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDerivativeDefinitions($basePluginDefinition) {
+    foreach ($this->getSectionTypeDefinitions() as $sectionType => $definition) {
+      if ($definition instanceof DocumentSectionDataDefinition) {
+        foreach ($definition->getPropertyDefinitions() as $propertyName => $propertyDefinition) {
+          $derivative = [
+            'parents' => [StringHelper::camelCase($sectionType)],
+            'name' => StringHelper::propCase($propertyName),
+            'type' => $propertyDefinition->isList() ? StringHelper::listType('Section') : $propertyDefinition->getDataType(),
+            'propertyName' => $propertyName,
+          ] + $basePluginDefinition;
+          $this->derivatives["{$sectionType}-$propertyName"] = $derivative;
+        }
+      }
+    }
+    return parent::getDerivativeDefinitions($basePluginDefinition);
+  }
+
+}

--- a/src/Plugin/Deriver/SectionTypeDeriver.php
+++ b/src/Plugin/Deriver/SectionTypeDeriver.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\ckeditor5_sections\Plugin\Deriver;
+
+use Drupal\graphql\Utility\StringHelper;
+
+/**
+ * Deriver for section types.
+ */
+class SectionTypeDeriver extends SectionDeriverBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDerivativeDefinitions($basePluginDefinition) {
+    foreach ($this->getSectionTypeDefinitions() as $sectionType => $definition) {
+      $derivative = [
+        'name' => StringHelper::camelCase($sectionType),
+        'interfaces' => ['Section'],
+        'type' => $sectionType,
+      ] + $basePluginDefinition;
+      $this->derivatives[$sectionType] = $derivative;
+    }
+    return parent::getDerivativeDefinitions($basePluginDefinition);
+  }
+
+}

--- a/src/Plugin/GraphQL/Fields/SectionProperty.php
+++ b/src/Plugin/GraphQL/Fields/SectionProperty.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\ckeditor5_sections\Plugin\GraphQL\Fields;
+
+use Drupal\ckeditor5_sections\DocumentSection;
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Fields\FieldPluginBase;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * @GraphQLField(
+ *   id = "section_property",
+ *   secure = true,
+ *   deriver = "Drupal\ckeditor5_sections\Plugin\Deriver\SectionPropertyDeriver",
+ * )
+ */
+class SectionProperty extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
+    if ($value instanceof DocumentSection) {
+      $result = $value->get($this->getPluginDefinition()['propertyName']);
+      if (is_array($result)) {
+        foreach ($result as $item) {
+          yield $item;
+        }
+      }
+      else {
+        yield $result;
+      }
+    }
+  }
+
+}

--- a/src/Plugin/GraphQL/Fields/SectionTypeField.php
+++ b/src/Plugin/GraphQL/Fields/SectionTypeField.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\ckeditor5_sections\Plugin\GraphQL\Fields;
+
+use Drupal\ckeditor5_sections\DocumentSection;
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Fields\FieldPluginBase;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * @GraphQLField(
+ *   id = "section_type",
+ *   secure = true,
+ *   name = "sectionType",
+ *   type = "String",
+ *   parents = {"Section"},
+ * )
+ */
+class SectionTypeField extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
+    if ($value instanceof DocumentSection) {
+      yield $value->getType();
+    }
+  }
+
+}

--- a/src/Plugin/GraphQL/Interfaces/Section.php
+++ b/src/Plugin/GraphQL/Interfaces/Section.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\ckeditor5_sections\Plugin\GraphQL\Interfaces;
+
+use Drupal\graphql\Plugin\GraphQL\Interfaces\InterfacePluginBase;
+
+/**
+ * @GraphQLInterface(
+ *   id = "section",
+ *   name = "Section",
+ *   type = "section",
+ *   description = @Translation("Section interface.")
+ * )
+ */
+class Section extends InterfacePluginBase {
+
+}

--- a/src/Plugin/GraphQL/Types/SectionType.php
+++ b/src/Plugin/GraphQL/Types/SectionType.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\ckeditor5_sections\Plugin\GraphQL\Types;
+
+use Drupal\ckeditor5_sections\DocumentSection;
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Types\TypePluginBase;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * @GraphQLType(
+ *   id = "section",
+ *   deriver = "Drupal\ckeditor5_sections\Plugin\Deriver\SectionTypeDeriver"
+ * )
+ */
+class SectionType extends TypePluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies($object, ResolveContext $context, ResolveInfo $info) {
+    return $object instanceof DocumentSection &&
+      $object->getType() === $this->getPluginDefinition()['type'];
+  }
+
+}


### PR DESCRIPTION
Having these editor templates

`page.html`
```
<div class="page" itemtype="page">
    <div itemprop="sections" ck-type="container" ck-contains="text button" class="page__content"></div>
</div>
```

`button.html`
```
<div class="button" data-button-style="light" itemtype="button">
    <div ck-type="button" link-target="" itemtype="buttonInner" itemprop="inner">
        <div ck-type="text" itemprop="text">Click me!</div>
    </div>
</div>
```

the module generates the following GraphQL schema:
<img width="963" alt="Screenshot 2019-04-16 at 11 51 10" src="https://user-images.githubusercontent.com/989015/56196012-b3113900-603e-11e9-8467-8de37b30e0de.png">

Example editor XML:
```
<div class="page" itemtype="page" id="mnsq9j">
    <div class="page__content" itemprop="sections">
        <div class="button" data-button-style="dark" itemtype="button">
            <div link-target="http://example.com" itemtype="buttonInner" itemprop="inner">
                <div class="" itemprop="text">
                    <p>Button!</p>
                </div>
            </div>
        </div>
    </div>
</div>
```

Example GraphQL query:
<img width="1005" alt="Screenshot 2019-04-16 at 11 45 30" src="https://user-images.githubusercontent.com/989015/56196057-cae8bd00-603e-11e9-9c54-b0922e25e04c.png">
