### PR TITLE
Adjust sections and test fixtures to correspond to post-'great cleanup'

### DIFF
--- a/sections/image/image.html
+++ b/sections/image/image.html
@@ -1,10 +1,10 @@
 <ck-section class="image" itemtype="image">
-  <div
+  <ck-media
        data-media-type="media:image"
        data-media-uuid=""
        itemprop="content"
        itemtype="media"
        class="image__media"
-  ></div>
+  ></ck-media>
   <div class="image__caption" ck-input="basic" itemprop="caption">Caption</div>
 </ck-section>

--- a/sections/page/page.html
+++ b/sections/page/page.html
@@ -1,3 +1,3 @@
-<div class="page" itemtype="page">
+<ck-section class="page" itemtype="page">
   <ck-container class="page__container" itemprop="sections" ck-contains="text image teaser"></ck-container>
-</div>
+</ck-section>

--- a/sections/teaser/teaser.html
+++ b/sections/teaser/teaser.html
@@ -1,10 +1,10 @@
 <ck-section class="teaser" itemtype="teaser" data-layout="">
-  <div data-media-type="media:image"
+  <ck-media data-media-type="media:image"
        data-media-uuid=""
        itemprop="image"
        itemtype="teaser-image"
        class="teaser__image"
-  ></div>
+  ></ck-media>
   <div class="teaser__content">
     <h2 ck-input="plain" itemprop="headline" class="teaser__headline">Headline</h2>
     <div ck-input="full" itemprop="text" class="teaser__text">Content</div>

--- a/tests/src/Kernel/assets/data/page.html
+++ b/tests/src/Kernel/assets/data/page.html
@@ -1,32 +1,33 @@
-<div class="page" itemtype="page">
-  <div class="page__container" itemprop="sections">
-    <div class="image" itemtype="image">
-      <div data-media-type="image"
+<ck-section class="page" itemtype="page">
+  <ck-container class="page__container" itemprop="sections">
+    <ck-section class="image" itemtype="image">
+      <ck-media data-media-type="image"
            data-media-uuid="123"
            itemprop="content"
            itemtype="media"
            class="image__media"
-      ></div>
+      ></ck-media>
       <div class="image__caption" itemprop="caption">Caption</div>
-    </div>
+    </ck-section>
     <div class="text" itemtype="text">
       <h2 itemprop="headline">Headline</h2>
       <div class="text__content" itemprop="content">Content</div>
     </div>
-    <div class="teaser" itemtype="teaser" data-layout="test">
-      <div data-media-type="image"
-           data-media-uuid="123"
-           itemprop="image"
-           itemtype="teaser-image"
-           class="teaser__image"
-      ></div>
+    <ck-section class="teaser" itemtype="teaser" data-layout="test">
+      <ck-media data-media-type="media:image"
+                data-media-uuid="123"
+                itemprop="image"
+                itemtype="teaser-image"
+                class="teaser__image"
+      ></ck-media>
+
       <div class="teaser__content">
-        <h2 class="teaser__headline" itemprop="headline">Title</h2>
-        <div class="teaser__text" itemprop="text"><p>This is the content.</p></div>
-        <a class="teaser__link" href="http://www.drupal.org" itemprop="link" itemtype="button">
-          <span itemprop="text">Click me!!!</span>
-        </a>
+        <h2 itemprop="headline" class="teaser__headline">Title</h2>
+        <div itemprop="text" class="teaser__text"><p>This is the content.</p></div>
+        <ck-button itemtype="button" itemprop="link" class="teaser__link" link-target="http://www.drupal.org">
+          <div itemprop="text">Click me!!!</div>
+        </ck-button>
       </div>
-    </div>
-  </div>
-</div>
+    </ck-section>
+  </ck-container>
+</ck-section>

--- a/tests/src/Kernel/assets/data/page.json
+++ b/tests/src/Kernel/assets/data/page.json
@@ -22,12 +22,12 @@
       "text": "<p>This is the content.</p>",
       "image": {
         "__type": "teaser-image",
-        "data-media-type": "image",
+        "data-media-type": "media:image",
         "data-media-uuid": "123"
       },
       "link": {
         "__type": "button",
-        "href": "http://www.drupal.org",
+        "link-target": "http://www.drupal.org",
         "text": "Click me!!!"
       }
     }

--- a/tests/src/Kernel/assets/data/teaser.html
+++ b/tests/src/Kernel/assets/data/teaser.html
@@ -1,15 +1,15 @@
-<div class="teaser" itemtype="teaser" data-layout="test">
-  <div data-media-type="image"
+<ck-section class="teaser" itemtype="teaser" data-layout="test">
+  <ck-media data-media-type="image"
        data-media-uuid="123"
        itemprop="image"
        itemtype="teaser-image"
        class="teaser__image"
-  ></div>
+  ></ck-media>
   <div class="teaser__content">
     <h2 class="teaser__headline" itemprop="headline">Title</h2>
     <div class="teaser__text" itemprop="text"><p>This is the content.</p></div>
-    <a class="teaser__link" href="http://www.drupal.org" itemprop="link" itemtype="button">
-      <span itemprop="text">Click me!!!</span>
-    </a>
+    <ck-button itemtype="button" itemprop="link" class="teaser__link" link-target="http://www.drupal.org">
+      <div itemprop="text">Click me!!!</div>
+    </ck-button>
   </div>
-</div>
+</ck-section>

--- a/tests/src/Kernel/assets/data/teaser.json
+++ b/tests/src/Kernel/assets/data/teaser.json
@@ -10,7 +10,7 @@
   },
   "link": {
     "__type": "button",
-    "href": "http://www.drupal.org",
+    "link-target": "http://www.drupal.org",
     "text": "Click me!!!"
   }
 }

--- a/tests/src/Kernel/assets/definitions/teaser.html
+++ b/tests/src/Kernel/assets/definitions/teaser.html
@@ -1,16 +1,15 @@
-<div class="teaser" itemtype="teaser" data-layout="">
-  <div ck-type="drupal-media"
-       data-media-type="image"
-       data-media-uuid=""
-       itemprop="image"
-       itemtype="image"
-       class="teaser__image"
-  ></div>
+<ck-section class="teaser" itemtype="teaser" data-layout="">
+  <ck-media data-media-type="media:image"
+            data-media-uuid=""
+            itemprop="image"
+            itemtype="teaser-image"
+            class="teaser__image"
+  ></ck-media>
   <div class="teaser__content">
-    <h2 ck-type="text" itemprop="headline" class="teaser__headline">Headline</h2>
-    <div ck-type="text" itemprop="text" class="teaser__text">Content</div>
-    <a ck-type="button" itemtype="button" itemprop="link" class="teaser__link" href="">
-      <span itemprop="text">Link text placeholder</span>
-    </a>
+    <h2 ck-input="plain" itemprop="headline" class="teaser__headline">Headline</h2>
+    <div ck-input="full" itemprop="text" class="teaser__text">Content</div>
+    <ck-button itemtype="button" itemprop="link" class="teaser__link" link-target="">
+      <div itemprop="text" ck-input="plain">Link text placeholder</div>
+    </ck-button>
   </div>
-</div>
+</ck-section>

--- a/tests/src/Kernel/assets/definitions/teaser.json
+++ b/tests/src/Kernel/assets/definitions/teaser.json
@@ -7,7 +7,7 @@
         "type": "string"
       },
       "image": {
-        "type": "section:image",
+        "type": "section:teaser-image",
         "label": "image"
       },
       "headline": {
@@ -24,8 +24,8 @@
       }
     }
   },
-  "image": {
-    "type": "image",
+  "teaser-image": {
+    "type": "teaser-image",
     "fields": {
       "data-media-type": {
         "label": "data-media-type",
@@ -40,8 +40,8 @@
   "button": {
     "type": "button",
     "fields": {
-      "href": {
-        "label": "href",
+      "link-target": {
+        "label": "link-target",
         "type": "string"
       },
       "text": {


### PR DESCRIPTION
The section-templates (sections/{section_type}/) and the tests fixtures/assets needed to be updated in order to reflect the changes introduced in the "great cleanup" (e.g. `ck-input` and web components).