### PR TITLE
Fix GraphQL schema generation

### DIFF
--- a/src/Plugin/Deriver/SectionDeriverBase.php
+++ b/src/Plugin/Deriver/SectionDeriverBase.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\ckeditor5_sections\Plugin\Deriver;
 
-use Drupal\ckeditor5_sections\SectionsCollectorInterface;
+use Drupal\ckeditor5_sections\DocumentConverterInterface;
 use Drupal\ckeditor5_sections\TypedData\DocumentSectionDataDefinition;
 use Drupal\Component\Plugin\Derivative\DeriverBase;
 use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
@@ -20,20 +20,20 @@ class SectionDeriverBase extends DeriverBase implements ContainerDeriverInterfac
   protected $typedDataManager;
 
   /**
-   * @var \Drupal\ckeditor5_sections\SectionsCollectorInterface
+   * @var \Drupal\ckeditor5_sections\DocumentConverter
    */
-  protected $sectionsCollector;
+  protected $documentConverter;
 
   /**
    * @param \Drupal\Core\TypedData\TypedDataManagerInterface $typedDataManager
-   * @param \Drupal\ckeditor5_sections\SectionsCollectorInterface $sectionsCollector
+   * @param \Drupal\ckeditor5_sections\DocumentConverterInterface $documentConverter
    */
   public function __construct(
     TypedDataManagerInterface $typedDataManager,
-    SectionsCollectorInterface $sectionsCollector
+    DocumentConverterInterface $documentConverter
   ) {
-    $this->sectionsCollector = $sectionsCollector;
     $this->typedDataManager = $typedDataManager;
+    $this->documentConverter = $documentConverter;
   }
 
   /**
@@ -42,7 +42,7 @@ class SectionDeriverBase extends DeriverBase implements ContainerDeriverInterfac
   public static function create(ContainerInterface $container, $base_plugin_id) {
     return new static(
       $container->get('typed_data_manager'),
-      $container->get('ckeditor5_sections.sections_collector')
+      $container->get('ckeditor5_sections.document_converter')
     );
   }
 
@@ -54,7 +54,7 @@ class SectionDeriverBase extends DeriverBase implements ContainerDeriverInterfac
    */
   protected function getSectionTypeDefinitions() {
     $result = [];
-    foreach ($this->sectionsCollector->getSections() as $sectionType => $section) {
+    foreach ($this->documentConverter->getSectionTypeDefinitions() as $sectionType => $section) {
       if ($this->typedDataManager->hasDefinition("section:{$sectionType}")) {
         $definition = $this->typedDataManager->createDataDefinition("section:{$sectionType}");
         $result[$definition->getDataType()] = $definition;


### PR DESCRIPTION
It was using names of templates, which is wrong. Now it uses names from
typed data.

It was working only when `itemtype` had the same name as the template 😅