### PR TITLE
Clear sections cache if there are changes in the editor config

### DIFF
--- a/ckeditor5_sections.services.yml
+++ b/ckeditor5_sections.services.yml
@@ -6,6 +6,8 @@ services:
   ckeditor5_sections.sections_collector:
     class: Drupal\ckeditor5_sections\SectionsCollector
     arguments: ['@entity_type.manager']
+    tags:
+      - { name: event_subscriber }
   ckeditor5_sections.document_converter:
     class: Drupal\ckeditor5_sections\DocumentConverter
     arguments:

--- a/src/SectionsCollector.php
+++ b/src/SectionsCollector.php
@@ -2,12 +2,15 @@
 
 namespace Drupal\ckeditor5_sections;
 
+use Drupal\Core\Config\ConfigEvents;
+use Drupal\Core\Config\ConfigImporterEvent;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Sections collector service class.
  */
-class SectionsCollector implements SectionsCollectorInterface {
+class SectionsCollector implements SectionsCollectorInterface, EventSubscriberInterface {
 
   /**
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
@@ -71,6 +74,32 @@ class SectionsCollector implements SectionsCollectorInterface {
       ];
     }
     return $sections;
+  }
+
+  /**
+   * Fires after the configuration import.
+   *
+   * @param \Drupal\Core\Config\ConfigImporterEvent $event
+   */
+  public function afterConfigImport(ConfigImporterEvent $event) {
+    foreach ($event->getChangelist() as $list) {
+      foreach ($list as $item) {
+        if (strpos($item, 'editor.editor.') === 0) {
+          // Clear sections cache if there are changes in the editor config.
+          $this->sections = NULL;
+          break 2;
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events = [];
+    $events[ConfigEvents::IMPORT][] = ['afterConfigImport'];
+    return $events;
   }
 
 }


### PR DESCRIPTION
We noticed that, after a fresh Drupal installation (with `silverback setup`), the GraphQL schema is not generated for editor sections. A debug showed that `SectionsCollector::getSections` has static cache which is not cleared during the config import.