### PR TITLE
Consider non-breaking spaces in empty elements

### DIFF
--- a/src/DocumentConverter.php
+++ b/src/DocumentConverter.php
@@ -357,6 +357,13 @@ class DocumentConverter implements DocumentConverterInterface {
             // If the field is just a simple (scalar) field, then we just dump
             // the entire html of the node in it for now.
             $item_field_data = $this->getDOMInnerHtml($node);
+            if (trim($item_field_data, " \t\n\r\0\x0B\xC2\xA0") === '') {
+              // CKEditor and friends sometimes use the non-breaking space
+              // character in empty elements for various reasons. Treat such
+              // cases as empty strings, so that the user code can perform the
+              // is-empty checks in an easy way.
+              $item_field_data = '';
+            }
           }
 
           // If we are in the context of a parent, then just set the item data


### PR DESCRIPTION
We have noticed that empty text elements contain a non-breaking space:
```
<div class="nobel-image__caption" itemprop="caption">&nbsp;</div>
```

When graphql_twig is used, we get this:
```
"caption": " "
```

Since this is not a regular space, we can't do
```
{% if caption | trim %}
```
Instead, the following is required
```
{% if caption | trim(" \t\n\r\0\x0B\xC2\xA0") %}
```
This does not look nice and makes the panda sad.

I thought we maybe can consider this case in DocumentConverter?