### PR TITLE
Consider non-breaking spaces with tags in empty elements

### DIFF
--- a/src/DocumentConverter.php
+++ b/src/DocumentConverter.php
@@ -401,9 +401,10 @@ class DocumentConverter implements DocumentConverterInterface {
             // If the field is just a simple (scalar) field, then we just dump
             // the entire html of the node in it for now.
             $item_field_data = $this->getDOMInnerHtml($node);
-            if (trim($item_field_data, " \t\n\r\0\x0B\xC2\xA0") === '') {
+            if (trim(strip_tags($item_field_data), " \t\n\r\0\x0B\xC2\xA0") === '') {
               // CKEditor and friends sometimes use the non-breaking space
-              // character in empty elements for various reasons. Treat such
+              // character in empty elements for various reasons. It could be
+              // just "&nbsp;" or something like "<p>&nbsp;</p>". Treat such
               // cases as empty strings, so that the user code can perform the
               // is-empty checks in an easy way.
               $item_field_data = '';


### PR DESCRIPTION
This is a tiny improvement for #28 to make `DocumentConverter` translate `<p>&nbsp;</p>` to an empty string.