### PR TITLE
Fix filter editor config

### DIFF
--- a/config/install/filter.format.sections_data.yml
+++ b/config/install/filter.format.sections_data.yml
@@ -1,11 +1,23 @@
-uuid: a3037983-654b-4410-9e47-481de0c59523
 langcode: de
 status: true
 dependencies:
   module:
+    - ckeditor5_sections
     - linkit
-    - token_filter
 name: 'Sections Data'
 format: sections_data
 weight: 0
-filters: []
+filters:
+  sections_media_caption:
+    id: sections_media_caption
+    provider: ckeditor5_sections
+    status: true
+    weight: 0
+    settings: {  }
+  linkit:
+    id: linkit
+    provider: linkit
+    status: true
+    weight: 1
+    settings:
+      title: true


### PR DESCRIPTION
Removes erroneous (vestigial?) `token_filter` dependency and uuid-property as well as adds minimal filter configuration.