### PR TITLE
Restore media entities in typed data.

### DIFF
--- a/tests/src/Kernel/DocumentConverterTest.php
+++ b/tests/src/Kernel/DocumentConverterTest.php
@@ -38,6 +38,7 @@ class DocumentConverterTest extends KernelTestBase {
   protected function setUp() {
     parent::setUp();
     $this->installConfig(['ckeditor5_sections']);
+    $this->installEntitySchema('media');
   }
 
   /**

--- a/tests/src/Kernel/assets/data/page.json
+++ b/tests/src/Kernel/assets/data/page.json
@@ -7,7 +7,8 @@
       "content": {
         "__type": "media",
         "data-media-type": "image",
-        "data-media-uuid": "123"
+        "data-media-uuid": "123",
+        "entity": null
       },
       "caption": "Caption"
     },
@@ -26,7 +27,8 @@
       "image": {
         "__type": "teaser-image",
         "data-media-type": "media:image",
-        "data-media-uuid": "123"
+        "data-media-uuid": "123",
+        "entity": null
       },
       "link": {
         "__type": "button",

--- a/tests/src/Kernel/assets/data/teaser.json
+++ b/tests/src/Kernel/assets/data/teaser.json
@@ -7,7 +7,8 @@
   "image": {
     "__type": "teaser-image",
     "data-media-type": "image",
-    "data-media-uuid": "123"
+    "data-media-uuid": "123",
+    "entity": null
   },
   "link": {
     "__type": "button",


### PR DESCRIPTION
This returns media entities into typed data.

Also, this might fix #41. But I'm not sure because currently there is no way to test editor with GraphQL.