### PR TITLE
Remove hard-dependency on core patch (from issue 2867707)

### DIFF
--- a/ckeditor5_sections.services.yml
+++ b/ckeditor5_sections.services.yml
@@ -32,10 +32,6 @@ services:
   media_library.opener.sections:
     class: Drupal\ckeditor5_sections\SectionsMediaLibraryOpener
     arguments: ['@entity_type.manager']
-  conflict_resolution.merge_sections_documents:
-    class: Drupal\ckeditor5_sections\ConflictResolution\MergeSectionsDocuments
-    tags:
-      - { name: event_subscriber }
 
 parameters:
   ckeditor5_sections.template_directory: false

--- a/src/Ckeditor5SectionsServiceProvider.php
+++ b/src/Ckeditor5SectionsServiceProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\ckeditor5_sections;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+
+/**
+ * Dynamically add services for ckeditor5_sections.
+ */
+class Ckeditor5SectionsServiceProvider extends ServiceProviderBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container) {
+    // Dynamically add conflict resolution if (core) patch introducing this
+    // functionality has been applied (@see https://www.drupal.org/node/2867707).
+    if (class_exists('Drupal\Core\Conflict\ConflictResolution\MergeStrategyBase')) {
+      $container
+        ->register('conflict_resolution.merge_sections_documents', 'Drupal\ckeditor5_sections\ConflictResolution\MergeSectionsDocuments')
+        ->addTag('event_subscriber');
+    }
+  }
+}


### PR DESCRIPTION
Without the [core patch introducing conflict management](https://www.drupal.org/files/issues/2019-06-24/2867707-33.drupal.WI-Phase-H-Conflict-management-and-local-workspace-merging-support.patch) `ckeditor5_sections` was triggering a fatal error as the base class for the `conflict_resolution.merge_sections_documents`-service was missing.

This PR switches to a dynamically declare service depending on whether the base class (by means of said patch) exists.

STR - without patch: 
1. `drush cr -y` 
2. No fatal errors in web frontend.
3. `drupal debug:container conflict_resolution.merge_sections_documents` returns error `  You have requested a non-existent service "conflict_resolution.merge_sections_documents".`

STR - with patch:
1. `drush cr -y` 
2. No fatal errors in web frontend.
3. `drupal debug:container conflict_resolution.merge_sections_documents` returns details of service.