### PR TITLE
Entity usage support

### DIFF
--- a/src/Plugin/EntityUsage/Track/CKEditor5SectionsBase.php
+++ b/src/Plugin/EntityUsage/Track/CKEditor5SectionsBase.php
@@ -12,7 +12,7 @@ abstract class CKEditor5SectionsBase extends EntityUsageTrackBase{
    * {@inheritdoc}
    */
   public function getTargetEntities(FieldItemInterface $item) {
-    $text = $item->html_processed;
+    $text = $item->html;
     if (empty($text)) {
       return [];
     }

--- a/src/Plugin/EntityUsage/Track/CKEditor5SectionsBase.php
+++ b/src/Plugin/EntityUsage/Track/CKEditor5SectionsBase.php
@@ -1,0 +1,43 @@
+<?php
+
+
+namespace Drupal\ckeditor5_sections\Plugin\EntityUsage\Track;
+
+use Drupal\Core\Field\FieldItemInterface;
+use Drupal\entity_usage\EntityUsageTrackBase;
+
+abstract class CKEditor5SectionsBase extends EntityUsageTrackBase{
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTargetEntities(FieldItemInterface $item) {
+    $text = $item->html_processed;
+    if (empty($text)) {
+      return [];
+    }
+    $entities_in_text = $this->parseEntitiesFromText($text);
+    $valid_entities = [];
+    foreach ($entities_in_text as $uuid => $entity_type) {
+      // Check if the target entity exists since text fields are not
+      // automatically updated when an entity is removed.
+      if ($target_entity = $this->entityRepository->loadEntityByUuid($entity_type, $uuid)) {
+        $valid_entities[] = $target_entity->getEntityTypeId() . "|" . $target_entity->id();
+      }
+    }
+    return array_unique($valid_entities);
+  }
+
+  /**
+   * Parse an HTML snippet looking for embedded entities.
+   *
+   * @param string $text
+   *   The partial (X)HTML snippet to load. Invalid markup will be corrected on
+   *   import.
+   *
+   * @return array
+   *   An array of all embedded entities found, where keys are the uuids and the
+   *   values are the entity types.
+   */
+  abstract public function parseEntitiesFromText($text);
+}

--- a/src/Plugin/EntityUsage/Track/CKEditor5SectionsButtons.php
+++ b/src/Plugin/EntityUsage/Track/CKEditor5SectionsButtons.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Drupal\ckeditor5_sections\Plugin\EntityUsage\Track;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Path\PathValidatorInterface;
+use Drupal\entity_usage\EntityUsage;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Tracks usage of entities in button sections fields.
+ *
+ * @EntityUsageTrack(
+ *   id = "sections_buttons",
+ *   label = @Translation("Sections buttons"),
+ *   description = @Translation("Tracks entity relationships created in button section fields."),
+ *   field_types = {"sections"},
+ * )
+ */
+class CKEditor5SectionsButtons extends CKEditor5SectionsBase {
+
+  /**
+   * The Drupal Path Validator service.
+   *
+   * @var \Drupal\Core\Path\PathValidatorInterface
+   */
+  protected $pathValidator;
+
+  /**
+   * Constructs the CKEditor5SectionsButtons plugin.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\entity_usage\EntityUsage $usage_service
+   *   The usage tracking service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The EntityTypeManager service.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
+   *   The EntityFieldManager service.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
+   *   The EntityRepositoryInterface service.
+   * @param \Drupal\Core\Path\PathValidatorInterface $path_validator
+   *   The Drupal Path Validator service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityUsage $usage_service, EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $entity_field_manager, ConfigFactoryInterface $config_factory, EntityRepositoryInterface $entity_repository, PathValidatorInterface $path_validator) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $usage_service, $entity_type_manager, $entity_field_manager, $config_factory, $entity_repository);
+    $this->pathValidator = $path_validator;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_usage.usage'),
+      $container->get('entity_type.manager'),
+      $container->get('entity_field.manager'),
+      $container->get('config.factory'),
+      $container->get('entity.repository'),
+      $container->get('path.validator')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function parseEntitiesFromText($text) {
+    $dom = Html::load($text);
+    $xpath = new \DOMXPath($dom);
+    $entities = [];
+    foreach ($xpath->query('//ck-button') as $node) {
+      $link_target = $node->getAttribute('link-target');
+      $target_type = $target_id = NULL;
+
+      // Check if the target links to an entity.
+      try {
+        $url = $this->pathValidator->getUrlIfValidWithoutAccessCheck($link_target);
+        if ($url && $url->isRouted() && preg_match('/^entity\./', $url->getRouteName())) {
+          // Ge the target entity type and ID.
+          $route_parameters = $url->getRouteParameters();
+          $target_type = array_keys($route_parameters)[0];
+          $target_id = $route_parameters[$target_type];
+        }
+        if ($target_type && $target_id) {
+          $entity = $this->entityTypeManager->getStorage($target_type)->load($target_id);
+          if ($entity) {
+            $entities[$entity->uuid()] = $target_type;
+          }
+        }
+      }
+      catch (\Exception $e) {
+        // Do nothing.
+      }
+    }
+    return $entities;
+  }
+
+}

--- a/src/Plugin/EntityUsage/Track/CKEditor5SectionsHtmlLink.php
+++ b/src/Plugin/EntityUsage/Track/CKEditor5SectionsHtmlLink.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Drupal\ckeditor5_sections\Plugin\EntityUsage\Track;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Path\PathValidatorInterface;
+use Drupal\Core\StreamWrapper\PublicStream;
+use Drupal\entity_usage\EntityUsage;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Tracks usage of entities in standard sections fields.
+ *
+ * This plugin handles both cases: links added with linkit or with plain html.
+ * So basically, it just ignored the data attributes that the linkit module
+ * adds. In the contrib module there is a very similar plugin, html_link, which
+ * ignores the links added with linkit.
+ *
+ * @EntityUsageTrack(
+ *   id = "sections_html_link",
+ *   label = @Translation("Sections HTML links"),
+ *   description = @Translation("Tracks relationships created with standard links in sections fields."),
+ *   field_types = {"sections"},
+ * )
+ */
+class CKEditor5SectionsHtmlLink extends CKEditor5SectionsBase {
+
+  /**
+   * The Drupal Path Validator service.
+   *
+   * @var \Drupal\Core\Path\PathValidatorInterface
+   */
+  protected $pathValidator;
+
+  /**
+   * The public file directory.
+   *
+   * @var string
+   */
+  protected $publicFileDirectory;
+
+  /**
+   * Constructs the CKEditor5SectionsHtmlLink plugin.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\entity_usage\EntityUsage $usage_service
+   *   The usage tracking service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The EntityTypeManager service.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
+   *   The EntityFieldManager service.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
+   *   The EntityRepositoryInterface service.
+   * @param \Drupal\Core\Path\PathValidatorInterface $path_validator
+   *   The Drupal Path Validator service.
+   * @param \Drupal\Core\StreamWrapper\PublicStream $public_stream
+   *   The Public Stream service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityUsage $usage_service, EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $entity_field_manager, ConfigFactoryInterface $config_factory, EntityRepositoryInterface $entity_repository, PathValidatorInterface $path_validator, PublicStream $public_stream) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $usage_service, $entity_type_manager, $entity_field_manager, $config_factory, $entity_repository);
+    $this->pathValidator = $path_validator;
+    $this->publicFileDirectory = $public_stream->getDirectoryPath();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_usage.usage'),
+      $container->get('entity_type.manager'),
+      $container->get('entity_field.manager'),
+      $container->get('config.factory'),
+      $container->get('entity.repository'),
+      $container->get('path.validator'),
+      $container->get('stream_wrapper.public')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function parseEntitiesFromText($text) {
+    $dom = Html::load($text);
+    $xpath = new \DOMXPath($dom);
+    $entities = [];
+
+    // Loop trough all the <a> elements.
+    $xpath_query = "//a[@href != '']";
+    foreach ($xpath->query($xpath_query) as $element) {
+      /** @var \DOMElement $element */
+      try {
+        // Get the href value of the <a> element.
+        $href = $element->getAttribute('href');
+
+        // Strip off the scheme and host, so we only get the path.
+        $site_domains = $this->config->get('site_domains') ?: [];
+        foreach ($site_domains as $site_domain) {
+          $host_pattern = '{^https?://' . str_replace('.', '\.', $site_domain) . '/}';
+          if (\preg_match($host_pattern, $href)) {
+            $href = preg_replace($host_pattern, '/', $href);
+            break;
+          }
+        }
+
+        $target_type = $target_id = NULL;
+
+        // Check if the href links to an entity.
+        $url = $this->pathValidator->getUrlIfValidWithoutAccessCheck($href);
+        if ($url && $url->isRouted() && preg_match('/^entity\./', $url->getRouteName())) {
+          // Ge the target entity type and ID.
+          $route_parameters = $url->getRouteParameters();
+          $target_type = array_keys($route_parameters)[0];
+          $target_id = $route_parameters[$target_type];
+        }
+        elseif (\preg_match('{^/?' . $this->publicFileDirectory . '/}', $href)) {
+          // Check if we can map the link to a public file.
+          $file_uri = preg_replace('{^/?' . $this->publicFileDirectory . '/}', 'public://', urldecode($href));
+          $files = $this->entityTypeManager->getStorage('file')->loadByProperties(['uri' => $file_uri]);
+          if ($files) {
+            // File entity found.
+            $target_type = 'file';
+            $target_id = array_keys($files)[0];
+          }
+        }
+
+        if ($target_type && $target_id) {
+          $entity = $this->entityTypeManager->getStorage($target_type)->load($target_id);
+          if ($entity) {
+            // No matter if this entity was referenced with linkit or not, we
+            // just added to the entities list. The html_link plugin
+            // ignores them because it has a separate plugin just for that.
+            $entities[$entity->uuid()] = $target_type;
+          }
+        }
+      }
+      catch (\Exception $e) {
+        // Do nothing.
+      }
+    }
+
+    return $entities;
+  }
+
+}

--- a/src/Plugin/EntityUsage/Track/CKEditor5SectionsMedia.php
+++ b/src/Plugin/EntityUsage/Track/CKEditor5SectionsMedia.php
@@ -3,19 +3,18 @@
 namespace Drupal\ckeditor5_sections\Plugin\EntityUsage\Track;
 
 use Drupal\Component\Utility\Html;
-use Drupal\entity_usage\Plugin\EntityUsage\Track\TextFieldEmbedBase;
 
 /**
- * Tracks usage of medias in sections fields.
+ * Tracks usage of media in sections fields.
  *
  * @EntityUsageTrack(
  *   id = "sections_media",
  *   label = @Translation("Sections media"),
- *   description = @Translation("Tracks relationships created with Sections in formatted text fields."),
- *   field_types = {"text_long", "text_with_summary"},
+ *   description = @Translation("Tracks media relationships created section fields."),
+ *   field_types = {"sections"},
  * )
  */
-class CKEditor5SectionsMedia extends TextFieldEmbedBase {
+class CKEditor5SectionsMedia extends CKEditor5SectionsBase {
 
   /**
    * {@inheritdoc}
@@ -25,7 +24,20 @@ class CKEditor5SectionsMedia extends TextFieldEmbedBase {
     $xpath = new \DOMXPath($dom);
     $entities = [];
     foreach ($xpath->query('//ck-media[@data-media-uuid]') as $node) {
-      $entities[$node->getAttribute('data-media-uuid')] = 'media';
+      // By default, the media widget references media entities. However, it is
+      // possible that it references other entity types as well. This is stored
+      // in the 'data-media-type' attribute, so we have to parse it and see if
+      // we do actually reference a media or some other entity type. The pattern
+      // of the 'data-media-type' is: "entity_type:entity_bundle".
+      // @todo: this ck-media element should probably be refactored and renamed
+      // to something like 'ck-entity'.
+      $enity_type = 'media';
+      $media_type_attribute = $node->getAttribute('data-media-type');
+      if (!empty($media_type_attribute)) {
+        $words = explode(':', $media_type_attribute);
+        $enity_type = $words[0];
+      }
+      $entities[$node->getAttribute('data-media-uuid')] = $enity_type;
     }
     return $entities;
   }

--- a/src/Plugin/EntityUsage/Track/CKEditor5SectionsMentionsBase.php
+++ b/src/Plugin/EntityUsage/Track/CKEditor5SectionsMentionsBase.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Drupal\ckeditor5_sections\Plugin\EntityUsage\Track;
+
+use Drupal\Component\Utility\Html;
+
+/**
+ * Base class for mentions entity usage tracker.
+ */
+abstract class CKEditor5SectionsMentionsBase extends CKEditor5SectionsBase {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function parseEntitiesFromText($text) {
+    $dom = Html::load($text);
+    $xpath = new \DOMXPath($dom);
+    $entities = [];
+    $mention_prefix = $this->getMentionPrefix();
+    foreach ($xpath->query("//span[@data-mention]") as $node) {
+      $mention = $node->getAttribute('data-mention');
+      if (strpos($mention, $mention_prefix) === 0) {
+        // The machine name of the mention we get by removing the mention
+        // prefix.
+        $machine_name = substr($mention, strlen($mention_prefix));
+        $mention_entities = $this->entityTypeManager->getStorage($this->getMentionEntityType())->loadByProperties(['machine_name' => $machine_name]);
+        if (!empty($mention_entities)) {
+          $mention_entity = reset($mention_entities);
+          $entities[$mention_entity->uuid()] = $this->getMentionEntityType();
+        }
+      }
+    }
+    return $entities;
+  }
+
+  /**
+   * Returns the prefix for this mention type.
+   */
+  abstract public function getMentionPrefix();
+
+  /**
+   * Returns the entity type of this mention.
+   */
+  abstract public function getMentionEntityType();
+}


### PR DESCRIPTION
This PR enhances the entity_usage integration by providing a few plugins which work with sections fields:
- media (and other entity embedded using the ck-media section).
- buttons (ck-button sections which reference internal entities)
- html links (plain html links, added either by linkit or by the ckeditor link plugin)
- base support for mentions (the actual tracking plugins has to be implemented in custom module, but they are very easy to be done, they just need to expose a prefix and the entity type of the mention).